### PR TITLE
Validation updated for Symfony 2.6

### DIFF
--- a/Validator/DniValidator.php
+++ b/Validator/DniValidator.php
@@ -2,10 +2,8 @@
 
 namespace Ideup\ExtraValidatorBundle\Validator;
 
-use
-    Symfony\Component\Validator\ConstraintValidator,
-    Symfony\Component\Validator\Constraint
-;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Constraint;
 
 class DniValidator extends ConstraintValidator
 {
@@ -13,8 +11,23 @@ class DniValidator extends ConstraintValidator
     protected $standardDniExpr = '/(^[0-9]{8}[A-Z]{1}$)/';
     protected $avaliableLastChar = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
-
+    /**
+     * @param $value
+     * @param Constraint $constraint
+     * @return bool
+     * @deprecated In Symfony 2.6 does not work but remains backward compatibility 2.3
+     */
     public function isValid($value, Constraint $constraint)
+    {
+        $this->validate($value, $constraint);
+    }
+
+    /**
+     * @param mixed $value
+     * @param Constraint $constraint
+     * @return bool
+     */
+    public function validate($value, Constraint $constraint)
     {
         $ret = $this->checkDni($value);
 

--- a/Validator/DniValidator.php
+++ b/Validator/DniValidator.php
@@ -32,7 +32,9 @@ class DniValidator extends ConstraintValidator
         $ret = $this->checkDni($value);
 
         if (!$ret) {
-            $this->setMessage($constraint->message);
+        	$this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $this->formatValue($value),
+            ));
         }
 
         return $ret;

--- a/Validator/PhoneValidator.php
+++ b/Validator/PhoneValidator.php
@@ -34,7 +34,9 @@ class PhoneValidator extends ConstraintValidator
         $ret = $this->validateNumber($value, $constraint->format);
 
         if (!$ret) {
-            $this->setMessage($constraint->message);
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $this->formatValue($value),
+            ));
         }
 
         return $ret;

--- a/Validator/PhoneValidator.php
+++ b/Validator/PhoneValidator.php
@@ -15,14 +15,20 @@ use Symfony\Component\Validator\Constraint;
 class PhoneValidator extends ConstraintValidator
 {
     /**
-     * @param string $value
+     * @param $value
      * @param Constraint $constraint
      * @return bool
+     * @deprecated In Symfony 2.6 does not work but remains backward compatibility 2.3
      */
     public function isValid($value, Constraint $constraint)
     {
+        $this->validate($value, $constraint);
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
         if (empty($value)) {
-           return true;
+            return true;
         }
 
         $ret = $this->validateNumber($value, $constraint->format);

--- a/Validator/PrefixPhone.php
+++ b/Validator/PrefixPhone.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraint;
 /**
  * @Annotation
  */
-class Phone extends Constraint
+class PrefixPhone extends Constraint
 {
     public $message = "It is not a valid phone number";
     public $format  = '/(\+\d{2,3})?\s+(\d{2,3}\s)+|(\d+)/';


### PR DESCRIPTION
Hello,

Symfony 2.6 For the `validate($value, $constraint Constraint)` method is mandatory. I kept the retro backward compatibility with previous versions.
